### PR TITLE
Fix installer shell compatibility on SRM

### DIFF
--- a/.github/workflows/installer-test.yml
+++ b/.github/workflows/installer-test.yml
@@ -1,0 +1,21 @@
+name: Installer tests
+
+on: [push, pull_request]
+
+jobs:
+  installer:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shell: [dash, 'busybox sh', bash]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shell test tools
+        run: sudo apt-get update && sudo apt-get install -y busybox shellcheck
+      - name: Check POSIX shell compatibility
+        run: shellcheck --shell=sh install.sh
+      - name: Test installer without root or network access
+        env:
+          INSTALL_TEST_SHELL: ${{ matrix.shell }}
+          PYTHONDONTWRITEBYTECODE: '1'
+        run: python3 -m unittest discover -s tests -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,30 @@ To run the unit tests:
 ./gradlew check
 ```
 
+### Testing the Installer
+
+Installer tests require Python 3 and the shell being tested, but no Synology
+device, root access, or network connection:
+
+```sh
+INSTALL_TEST_SHELL=dash PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
+shellcheck --shell=sh install.sh
+```
+
+CI also runs these tests with `INSTALL_TEST_SHELL='busybox sh'` and `bash`.
+The tests redirect installation paths into a temporary directory and stub
+architecture detection, downloads, and privilege elevation. They verify ARM64
+and x64 asset selection, permissions, provider configuration output, unsupported
+architectures, and download failure handling. They do not run the native agent
+or verify SRM's utilities, existing provider replacement, or DDNS integration.
+
+For device QA, use the candidate `install.sh` (the `master` download command
+will only include the fix after it is merged). Record the model, SRM version,
+and `uname -m`; run `sudo sh install.sh`; confirm that Cloudflare appears in
+the DDNS provider list; then test a disposable DNS record and verify its value
+in Cloudflare. Share the installer output and DDNS result with credentials
+removed. Shell tests alone should not be reported as full SRM certification.
+
 ### Building for Linux (Cross-Compilation)
 
 Since this is a Kotlin Native project, building Linux binaries on macOS requires Docker.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ This project is based on [the original PHP version of the agent](https://github.
 * Compatible with both IPv4 and IPv6 dual stack.
 
 ## SRM Support
-[SRM-based devices](https://www.synology.com/en-global/products/routers) use the Linux ARM64 architecture. The agent has a build target for Linux ARM64 and works on SRM devices. You can download the latest release for Linux ARM64 from the [releases page](https://github.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/releases).
+The installer supports `aarch64` (Linux ARM64) and `x86_64` systems. Linux ARM64 binaries are available on the [releases page](https://github.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/releases).
+
+Use `sudo sh install.sh`: SRM may not include Bash. The installer uses `/bin/sh` syntax and has isolated shell compatibility tests. The reporter of [issue #8](https://github.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/issues/8) confirmed that invoking the installer with `sh` works on an RT6600ax running SRM 1.3.2-9366 Update 2. Full installation and DDNS operation still need verification on the target SRM device; shell tests do not establish firmware or binary compatibility.
 
 ## Build the agent locally
 
@@ -129,7 +131,7 @@ This is the easiest and most reliable method. It runs the agent periodically via
    SSH into your Synology device and run the installation script:
 
    ```bash
-   wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/master/install.sh -O install.sh && sudo bash install.sh
+   wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/master/install.sh -O install.sh && sudo sh install.sh
    ```
    
    This will download the correct binary for your system to `/usr/syno/bin/ddns/KTSynologyDDNSCloudflareMultidomain.kexe`.
@@ -180,7 +182,7 @@ This method integrates the agent into Synology's "External Access" > "DDNS" menu
 2. **Connect via SSH:** Connect to your supported device via SSH and run this command:
 
   ```
-  wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/master/install.sh -O install.sh && sudo bash install.sh
+  wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/master/install.sh -O install.sh && sudo sh install.sh
   ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,9 @@ This project is based on [the original PHP version of the agent](https://github.
 * Compatible with both IPv4 and IPv6 dual stack.
 
 ## SRM Support
-[SRM-based devices](#https://www.synology.com/en-global/products/routers) use the Linux Arm64 architecture. The agent has a build target for Linux Arm64 and should work on SRM devices. However, it needs to be built locally and tested on SRM devices. Currently, it has not been tested on SRM devices, and there is no established build process for Linux Arm64.
+The installer supports `aarch64` (Linux ARM64) and `x86_64` systems. Linux ARM64 binaries are available on the [releases page](https://github.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/releases).
+
+Use `sudo sh install.sh`: SRM may not include Bash. The installer uses `/bin/sh` syntax and has isolated shell compatibility tests. The reporter of [issue #8](https://github.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/issues/8) confirmed that invoking the installer with `sh` works on an RT6600ax running SRM 1.3.2-9366 Update 2. Full installation and DDNS operation still need verification on the target SRM device; shell tests do not establish firmware or binary compatibility.
 
 ## Build the agent locally
 
@@ -121,7 +123,7 @@ If you haven't setup this access, see the following Synology Knowledge Base arti
 2. **Connect via SSH:** Connect to your supported device via SSH and run this command:
 
   ```
-  wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/master/install.sh -O install.sh && sudo bash install.sh
+  wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/master/install.sh -O install.sh && sudo sh install.sh
   ```
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # Check if system is LinuxX64 or LinuxArm64
 ARCH=$(uname -m)
-if [[ "$ARCH" == "aarch64" ]]; then
+if [ "$ARCH" = "aarch64" ]; then
     SYSTEM="LinuxArm64"
-elif [[ "$ARCH" == "x86_64" ]]; then
+elif [ "$ARCH" = "x86_64" ]; then
     SYSTEM="LinuxX64"
 else
     echo "Unsupported architecture: $ARCH"
@@ -17,9 +17,7 @@ DOWNLOAD_PATH="/tmp/KTSynologyDDNSCloudflareMultidomain${SYSTEM}.kexe"
 
 # Download the latest release based on the system
 echo "Downloading from $REPO_URL..."
-curl -L -o "$DOWNLOAD_PATH" "$REPO_URL"
-
-if [ $? -ne 0 ]; then
+if ! curl -L -o "$DOWNLOAD_PATH" "$REPO_URL"; then
     echo "Failed to download the latest release for $SYSTEM."
     exit 1
 fi
@@ -33,13 +31,12 @@ sudo chmod 755 "$TARGET_FILE"
 
 # Modify /etc.defaults/ddns_provider.conf
 CONF_FILE="/etc.defaults/ddns_provider.conf"
-STRING_TO_ADD="[Cloudflare]\n  modulepath=/usr/syno/bin/ddns/KTSynologyDDNSCloudflareMultidomain.kexe\n  queryurl=https://www.cloudflare.com/"
 
 if grep -q "\[Cloudflare\]" "$CONF_FILE"; then
     echo "Removing existing Cloudflare configuration..."
     sudo sed -i '/^\[Cloudflare\]/,/^\[/ { /^\[Cloudflare\]/d; /^\[/!d; }' "$CONF_FILE"
 fi
 
-echo -e "$STRING_TO_ADD" | sudo tee -a "$CONF_FILE" > /dev/null
+printf '%s\n' '[Cloudflare]' "  modulepath=$TARGET_FILE" '  queryurl=https://www.cloudflare.com/' | sudo tee -a "$CONF_FILE" > /dev/null
 
 echo "Installation complete for $SYSTEM."

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,99 @@
+"""Exercise the installer without root, network access, or Synology hardware.
+
+Run with: INSTALL_TEST_SHELL=dash python3 -m unittest discover -s tests -v
+Only filesystem paths are redirected in a temporary copy of the installer.
+"""
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class InstallerTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.target = self.root / "agent.kexe"
+        self.conf = self.root / "ddns_provider.conf"
+        self.original_conf = "[OtherProvider]\n  queryurl=https://example.com/\n"
+        self.conf.write_text(self.original_conf)
+        self.shell = shlex.split(os.environ.get("INSTALL_TEST_SHELL", "sh"))
+        self.shell[0] = shutil.which(self.shell[0]) or self.shell[0]
+        # No bash, real sudo, or real curl is reachable through PATH.
+        for command in ("grep", "mv", "chmod", "tee", "sed"):
+            (self.bin / command).symlink_to(shutil.which(command))
+        self.stub("uname", 'printf "%s\\n" "$TEST_ARCH"')
+        self.stub("sudo", 'exec "$@"')
+        self.stub("curl", '''
+if [ "$TEST_DOWNLOAD_FAIL" = 1 ]; then exit 7; fi
+[ "$1" = -L ] && [ "$2" = -o ] && [ "$#" = 4 ] || exit 2
+printf '%s\\n' "$4" > "$3"
+''')
+        source = (ROOT / "install.sh").read_text()
+        source = source.replace(
+            "/usr/syno/bin/ddns/KTSynologyDDNSCloudflareMultidomain.kexe",
+            str(self.target),
+        ).replace("/etc.defaults/ddns_provider.conf", str(self.conf))
+        source = source.replace("/tmp/KTSynology", str(self.root / "KTSynology"))
+        self.script = self.root / "install.sh"
+        self.script.write_text(source)
+
+    def stub(self, name, body):
+        path = self.bin / name
+        path.write_text("#!/bin/sh\n" + body + "\n")
+        path.chmod(0o755)
+
+    def run_installer(self, arch, download_fail=False):
+        return subprocess.run(
+            self.shell + [str(self.script)],
+            env={**os.environ, "PATH": str(self.bin), "TEST_ARCH": arch,
+                 "TEST_DOWNLOAD_FAIL": "1" if download_fail else "0"},
+            capture_output=True, text=True, timeout=10,
+        )
+
+    def assert_installed(self, arch, asset):
+        result = self.run_installer(arch)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(
+            self.target.read_text(),
+            "https://github.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/"
+            "releases/latest/download/" + asset + "\n",
+        )
+        self.assertEqual(self.target.stat().st_mode & 0o777, 0o755)
+        self.assertEqual(
+            self.conf.read_text(), self.original_conf +
+            "[Cloudflare]\n  modulepath=" + str(self.target) +
+            "\n  queryurl=https://www.cloudflare.com/\n",
+        )
+
+    def test_arm64_install_without_bash(self):
+        self.assert_installed("aarch64", "KTSynologyDDNSCloudflareMultidomainLinuxArm64.kexe")
+
+    def test_x64_install_without_bash(self):
+        self.assert_installed("x86_64", "KTSynologyDDNSCloudflareMultidomainLinuxX64.kexe")
+
+    def test_unsupported_architecture_leaves_system_unchanged(self):
+        result = self.run_installer("armv7l")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unsupported architecture", result.stdout)
+        self.assertFalse(self.target.exists())
+        self.assertEqual(self.conf.read_text(), self.original_conf)
+
+    def test_download_failure_preserves_existing_installation(self):
+        self.target.write_text("existing agent")
+        result = self.run_installer("aarch64", download_fail=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to download", result.stdout)
+        self.assertEqual(self.target.read_text(), "existing agent")
+        self.assertEqual(self.conf.read_text(), self.original_conf)


### PR DESCRIPTION
Fixes #8.

The documented `sudo bash install.sh` command fails on SRM systems without Bash. Use `sudo sh install.sh` in both installation guides and make the installer use `/bin/sh`, portable `[ ... ]` comparisons, and `printf` for the DDNS provider configuration.

Add isolated installer tests for ARM64 and x64 asset selection, executable permissions, configuration output, unsupported architectures, and download failure handling. Add CI coverage under dash, BusyBox sh, and Bash, plus ShellCheck.

Validation: all four installer tests pass locally under dash, sh, and Bash (12 successful executions); `shellcheck --shell=sh install.sh` and `git diff --check` pass. BusyBox validation is configured in CI and was not run locally. Native-agent tests were not rerun because this change only affects the installer and documentation.

This PR remains a draft pending CI and device QA. No RT6600ax or SRM device was available. The tests redirect filesystem paths and stub downloads, architecture detection, and privilege elevation; they do not establish native-binary or firmware compatibility. CONTRIBUTING.md documents the remaining device check: run the candidate installer, confirm Cloudflare appears as a DDNS provider, and verify an update to a disposable DNS record.

Candidate installer for device QA:

```sh
wget https://raw.githubusercontent.com/mrikirill/KTSynologyDDNSCloudflareMultidomain/feature/fix-srm-sh-installer/install.sh -O install.sh && sudo sh install.sh
```

Record the model, SRM version, `uname -m`, installer output, and DDNS result, with credentials removed.